### PR TITLE
Added sense of time

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A smarter SMB password sprayer with customizable options
 ```
 SMBSpray v1.2
 
-usage: smbspray.py [-h] [-u users] [-U user] [-p passwords] [-P password] [-d domain] [-l minutes] [-a attempts] -ip IP/hostname [--threads threads] [--verbose] [--user_pw][--unsafe]
+usage: smbspray.py [-h] [-u users] [-U user] [-p passwords] [-P password] [-d domain] [-l minutes] [-a attempts] -ip IP/hostname [--threads threads] [--verbose] [--user_pw] [--unsafe] [--no-interaction]
 
 Parse Spray Arguments.
 
@@ -24,6 +24,7 @@ optional arguments:
   --verbose          Verbose Mode
   --user_pw          Try username variations as password
   --unsafe           Keep spraying even if there are multiple account lockouts
+  --no-interaction   Do not ask for user input
   ```
 
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A smarter SMB password sprayer with customizable options
 ```
 SMBSpray v1.2
 
-usage: smbspray.py [-h] [-u users] [-U user] [-p passwords] [-P password] [-d domain] [-l minutes] [-a attempts] -ip IP/hostname [--threads threads] [--verbose] [--user_pw] [--unsafe] [--no-interaction]
+usage: smbspray.py [-h] [-u users] [-U user] [-p passwords] [-P password] [-d domain] [-l minutes] [-a attempts] -ip IP/hostname [--threads threads] [--verbose] [--user_pw] [--unsafe] [--no-interaction] [--start-time HH:MM] [--end-time HH:MM]
 
 Parse Spray Arguments.
 
@@ -25,6 +25,8 @@ optional arguments:
   --user_pw          Try username variations as password
   --unsafe           Keep spraying even if there are multiple account lockouts
   --no-interaction   Do not ask for user input
+  --start-time HH:MM Start time for allowed operation
+  --end-time HH:MM   End time for allowed operation
   ```
 
 

--- a/smbspray.py
+++ b/smbspray.py
@@ -34,7 +34,7 @@ smb_error_status = [
 
 # taken from CME
 def check_if_admin(conn):
-        rpctransport = SMBTransport(conn.getRemoteHost(), 445, r'\svcctl', smb_connection=conn)
+        rpctransport = SMBTransport(conn.getRemoteHost(), 445, r'\\svcctl', smb_connection=conn)
         dce = rpctransport.get_dce_rpc()
         try:
             dce.connect()
@@ -93,10 +93,10 @@ def login(username, password, domain, host, verbose=False):
                 else:
                     ip = host
                 if is_admin:
-                    message = get_pretty_time("success") + "{}:{}\t{}{}\{}:{} ".format(ip,hostname,colored("[+] ","green", attrs=['bold']),domain,username,password) + colored("(ADMIN!)","green", attrs=['bold'])
+                    message = get_pretty_time("success") + "{}:{}\t{}{}\\{}:{} ".format(ip,hostname,colored("[+] ","green", attrs=['bold']),domain,username,password) + colored("(ADMIN!)","green", attrs=['bold'])
 
                 else:
-                    message = get_pretty_time("success") + "{}:{}\t{}{}\{}:{} ".format(ip,hostname,colored("[+] ","green", attrs=['bold']),domain,username,password)
+                    message = get_pretty_time("success") + "{}:{}\t{}{}\\{}:{} ".format(ip,hostname,colored("[+] ","green", attrs=['bold']),domain,username,password)
                 
                 with open(valid_creds, "a+") as f:
                     f.write(domain + "\\" + username + ":" + password + "\r\n")
@@ -114,13 +114,13 @@ def login(username, password, domain, host, verbose=False):
                 domain = smbclient.getServerDNSDomainName()
             
             if error in smb_error_status:
-                message = get_pretty_time("warn") + "{}:{}\t{}{}\{}:{} ".format(ip,hostname,colored("[-] ","yellow", attrs=['bold']),domain,username,password) + colored(error,"yellow", attrs=['bold'])
+                message = get_pretty_time("warn") + "{}:{}\t{}{}\\{}:{} ".format(ip,hostname,colored("[-] ","yellow", attrs=['bold']),domain,username,password) + colored(error,"yellow", attrs=['bold'])
             elif error == smb_error_locked:
-                message = get_pretty_time("danger") + "{}:{}\t{}{}\{}:{} ".format(ip,hostname,colored("[!] ","red", attrs=['bold']),domain,username,password) +  colored(error,"red", attrs=['bold'])
+                message = get_pretty_time("danger") + "{}:{}\t{}{}\\{}:{} ".format(ip,hostname,colored("[!] ","red", attrs=['bold']),domain,username,password) +  colored(error,"red", attrs=['bold'])
                 print(message)
                 raise Locked(username)
             else:
-                message = get_pretty_time() + "{}:{}\t{}{}\{}:{} ".format(ip,hostname,colored("[-] ","red", attrs=['bold']),domain,username,password) + error
+                message = get_pretty_time() + "{}:{}\t{}{}\\{}:{} ".format(ip,hostname,colored("[-] ","red", attrs=['bold']),domain,username,password) + error
             smbclient.close()
         print(message)
         if verbose and desc:
@@ -263,10 +263,11 @@ def main():
     parser.add_argument('--verbose', help="Verbose Mode", action='store_true')
     parser.add_argument('--user_pw', help="Try username variations as password", action='store_true')
     parser.add_argument('--unsafe', help="Keep spraying even if there are multiple account lockouts", action='store_true')
+    parser.add_argument('--no-interaction', help="Run without interactive input", action='store_true')
     
     args = parser.parse_args()
     if len(sys.argv) == 1:
-            parser.print_help()
+        parser.print_help()
 
     global domain
     global host
@@ -275,7 +276,7 @@ def main():
     global total_passwords
     global lockout_period
     global i
-    global unsafe 
+    global unsafe
     global locked_users
     global threads
     domain = args.d 
@@ -292,11 +293,11 @@ def main():
     i = 0
 
     if not args.u and not args.U:
-        print(colored("[!] No users to spray... exiting", "red",attrs=['bold']))
+        print(colored("[!] No users to spray... exiting", "red", attrs=['bold']))
         sys.exit()
     
     if not args.p and not args.P:
-        print(colored("[!] No passwords to spray... exiting", "red",attrs=['bold']))
+        print(colored("[!] No passwords to spray... exiting", "red", attrs=['bold']))
         sys.exit()
     
     if not domain:
@@ -329,9 +330,8 @@ def main():
             for tried_password in tried_passwords:
                 if tried_password in password_list:
                     password_list.remove(tried_password)
-                    print(colored("[*] {} already attempted, removed from spray list".format(tried_password), "yellow",attrs=['bold']))
+                    print(colored("[*] {} already attempted, removed from spray list".format(tried_password), "yellow", attrs=['bold']))
 
-    
     total_passwords = len(password_list)
 
     # add three total passwords to try for username variations
@@ -339,7 +339,7 @@ def main():
         total_passwords += 3
     
     if total_passwords == 0:
-        print(colored("[!] No passwords to spray... exiting", "red",attrs=['bold']))
+        print(colored("[!] No passwords to spray... exiting", "red", attrs=['bold']))
         sys.exit()
 
     # ugly math for rough estimate of time to completion
@@ -350,19 +350,21 @@ def main():
         mathz = lockout_period * mathz1 - lockout_period
 
     print(colored("[*] Attempting {} passwords every {} minutes for {} total passwords".format(attempts, lockout_period, total_passwords),"yellow",attrs=['bold']))
-    if total_passwords <= attempts:
-        print(colored("[*] This will run to completion without sleeping", "yellow",attrs=['bold']))
-        input(colored("[*] Press Enter to proceed","yellow",attrs=['bold']))
-    else: 
-        print(colored("[*] This will take just over {} minutes to complete".format(mathz),"yellow",attrs=['bold']))
-        input(colored("[*] Press Enter to proceed","yellow",attrs=['bold']))
     
+    if not args.no_interaction:
+        if total_passwords <= attempts:
+            print(colored("[*] This will run to completion without sleeping", "yellow", attrs=['bold']))
+            input(colored("[*] Press Enter to proceed", "yellow", attrs=['bold']))
+        else: 
+            print(colored("[*] This will take just over {} minutes to complete".format(mathz), "yellow", attrs=['bold']))
+            input(colored("[*] Press Enter to proceed", "yellow", attrs=['bold']))
+
     # do username variations as passwords
     if args.user_pw:
-        print(get_pretty_time("warn") + colored("Trying username password variations","yellow",attrs=['bold']))
-        try_password(user_list,"", threads, option="lower", unsafe=unsafe)
-        try_password(user_list,"", threads, option="upper", unsafe=unsafe)
-        try_password(user_list,"", threads, option="capital", unsafe=unsafe)
+        print(get_pretty_time("warn") + colored("Trying username password variations", "yellow", attrs=['bold']))
+        try_password(user_list, "", threads, option="lower", unsafe=unsafe)
+        try_password(user_list, "", threads, option="upper", unsafe=unsafe)
+        try_password(user_list, "", threads, option="capital", unsafe=unsafe)
 
     # iterate through passwords list
     if password_list:


### PR DESCRIPTION
smbspray already offers functionalities to avoid the blocking of accounts. But sometimes you have to assume the biggest idiot in front of the computer. so if i automatically tried the password of a user 5 times and the user then mistyped it twice, the account was blocked. that's why i introduced two arguments. so you can set the start and end time of the scan. i can start a scan and it only starts at night and ends before a normal user goes about their daily business. When it gets night again, smbspray continues scanning. 